### PR TITLE
Bugfix/deregister event callbacks on unmount

### DIFF
--- a/app/components/app.react.js
+++ b/app/components/app.react.js
@@ -19,9 +19,13 @@ class App extends React.Component {
     );
   }
 
-  componentWillMount(){
-    this.props.store.addChangeListener('changed', this.handleDataChanged.bind(this));
+  componentWillMount() {
+    this.deregisterChangeListener = this.props.store.addChangeListener('changed', this.handleDataChanged.bind(this));
     this.props.actionCreator.initialize();
+  }
+
+  componentWillUnmount() {
+    this.deregisterChangeListener();
   }
 
   filterByIntensity(intensity) {

--- a/app/components/app.react.js
+++ b/app/components/app.react.js
@@ -19,7 +19,7 @@ class App extends React.Component {
     );
   }
 
-  componentWillMount() {
+  componentDidMount() {
     this.deregisterChangeListener = this.props.store.addChangeListener('changed', this.handleDataChanged.bind(this));
     this.props.actionCreator.initialize();
   }

--- a/app/flux/store.js
+++ b/app/flux/store.js
@@ -1,20 +1,31 @@
+function removeChangeListenerWithId(listenerId, eventIdentifier, store) {
+  store.listeners[eventIdentifier] = store.listeners[eventIdentifier]
+    .filter((listener) => { return listener.id !== listenerId; });
+};
+
 class Store {
   constructor() {
     this.listeners = {};
+    this.highestCallbackId = 0;
   }
 
   addChangeListener(eventIdentifier, callback) {
+    var callbackWithId = { callback: callback, id: this.highestCallbackId };
+    this.highestCallbackId++;
+
     if(!this.listeners[eventIdentifier]) {
       this.listeners[eventIdentifier] = [];
     }
-    this.listeners[eventIdentifier].push(callback);
+
+    this.listeners[eventIdentifier].push(callbackWithId);
+    return () => { removeChangeListenerWithId(callbackWithId.id, eventIdentifier, this)};
   }
 
   emitChange(eventIdentifier) {
     var listenersForEvent = this.listeners[eventIdentifier];
     if(listenersForEvent) {
       listenersForEvent.forEach((listener) => {
-        listener();
+        listener.callback();
       })
     }
   }

--- a/app/flux/store.js
+++ b/app/flux/store.js
@@ -6,26 +6,26 @@ function removeChangeListenerWithId(listenerId, eventIdentifier, store) {
 class Store {
   constructor() {
     this.listeners = {};
-    this.highestCallbackId = 0;
+    this.highestListenerId = 0;
   }
 
-  addChangeListener(eventIdentifier, callback) {
-    var callbackWithId = { callback: callback, id: this.highestCallbackId };
-    this.highestCallbackId++;
+  addChangeListener(eventIdentifier, listener) {
+    var listenerWithId = { execute: listener, id: this.highestListenerId };
+    this.highestListenerId++;
 
     if(!this.listeners[eventIdentifier]) {
       this.listeners[eventIdentifier] = [];
     }
 
-    this.listeners[eventIdentifier].push(callbackWithId);
-    return () => { removeChangeListenerWithId(callbackWithId.id, eventIdentifier, this)};
+    this.listeners[eventIdentifier].push(listenerWithId);
+    return () => { removeChangeListenerWithId(listenerWithId.id, eventIdentifier, this)};
   }
 
   emitChange(eventIdentifier) {
     var listenersForEvent = this.listeners[eventIdentifier];
     if(listenersForEvent) {
       listenersForEvent.forEach((listener) => {
-        listener.callback();
+        listener.execute();
       })
     }
   }

--- a/tests/flux/store.test.js
+++ b/tests/flux/store.test.js
@@ -12,7 +12,7 @@ describe('store', () => {
   });
 
   describe('emitting an event', () => {
-    it('should execute all change listeners registered for that event', function() {
+    it('should execute all change listeners registered for that event', () => {
       var callbackA = sinon.spy();
       var callbackB = sinon.spy();
       var callbackC = sinon.spy();
@@ -28,6 +28,29 @@ describe('store', () => {
       expect(callbackA).to.have.been.called;
       expect(callbackB).to.have.been.called;
       expect(callbackC).not.to.have.been.called;
+    });
+
+    describe('after change listener deregistered', () => {
+      it('should not execute deregistered listener', () => {
+        var callbackA = sinon.spy();
+        var callbackB = sinon.spy();
+        var callbackC = sinon.spy();
+        var payload = {pay: 'load'};
+        var changeEvent = 'somethingChanged';
+
+        var deregisterA = store.addChangeListener(changeEvent, callbackA);
+        var deregisterB = store.addChangeListener(changeEvent, callbackB);
+        var deregisterC = store.addChangeListener(changeEvent, callbackC);
+
+        deregisterA();
+        deregisterC();
+        
+        store.emitChange(changeEvent);
+
+        expect(callbackA).not.to.have.been.called;
+        expect(callbackB).to.have.been.called;
+        expect(callbackC).not.to.have.been.called;
+      });
     });
   });
 });


### PR DESCRIPTION
closes #9 
store.addChangeListener() returns a function that can be called to deregister that change listener.
